### PR TITLE
fix: tags on Project component made responsive with flex-wrap

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "astro-boilerplate-components",
-  "version": "1.0.6",
+  "version": "1.0.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "astro-boilerplate-components",
-      "version": "1.0.6",
+      "version": "1.0.8",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^17.0.2",

--- a/src/components/Project.tsx
+++ b/src/components/Project.tsx
@@ -30,7 +30,7 @@ const Project = (props: IProjectProps) => (
           <div className="text-xl font-semibold">{props.name}</div>
         </a>
 
-        <div className="ml-3 flex gap-2">{props.category}</div>
+        <div className="ml-3 flex flex-wrap gap-2">{props.category}</div>
       </div>
 
       <p className="mt-3 text-gray-400">{props.description}</p>


### PR DESCRIPTION
"Adding extra Categories Tags breaks the UI fluidity on mobile apps" [issue](https://github.com/ixartz/Astro-boilerplate/issues/7) fixed with `flex-wrap`.